### PR TITLE
Exposing message room to jobs

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,6 +26,9 @@ module.exports = function(bot){
       message.send(msg);
     }
   }
+  function sendMessagetoRoom(bot, msg, room = room) {
+    bot.messageRoom(room, msg);
+  }
 
   scheduler().initializeScheduledJobs(bot);
 
@@ -64,6 +67,9 @@ module.exports = function(bot){
           {
             send: function(msg){
               sendMessage(bot,message,msg);
+            },
+            messageRoom: function (msg, room) {
+              sendMessagetoRoom(bot, msg, room)
             }
           }
         );

--- a/index.js
+++ b/index.js
@@ -16,13 +16,13 @@ module.exports = function (bot) {
     hubot list scheduled jobs
     */
 
-  let scheduler = () => bot.Scheduler || Scheduler;
+  const scheduler = () => bot.Scheduler || Scheduler;
 
-  var mainRoom = process.env.HUBOT_JOB_CHANNEL;
+  const room = process.env.HUBOT_JOB_CHANNEL;
 
-  function sendMessage(bot, message, msg, room = mainRoom) {
-    bot.messageRoom(room, msg);
-    if (message && message.envelope && message.envelope.room !== mainRoom) {
+  function sendMessage(bot, message, msg, channel = room) {
+    bot.messageRoom(channel, msg);
+    if (message && message.envelope && message.envelope.room !== room) {
       message.send(msg);
     }
   }
@@ -30,12 +30,12 @@ module.exports = function (bot) {
   scheduler().initializeScheduledJobs(bot);
 
   bot.respond(/run job (.+)$/i, function (message) {
-    var ref = message.match.slice(1);
-    var fn = ref[0];
+    const ref = message.match.slice(1);
+    const fn = ref[0];
     return scheduler().jobFunctions[fn](
       {
-        send: function (msg, room = mainRoom) {
-          sendMessage(bot, message, msg, room);
+        send: function (msg, channel = room) {
+          sendMessage(bot, message, msg, channel);
         },
         bot
       }
@@ -43,8 +43,8 @@ module.exports = function (bot) {
   });
 
   bot.respond(/delete scheduled job (.+)$/i, function (message) {
-    var ref = message.match.slice(1);
-    var fn = ref[0];
+    const ref = message.match.slice(1);
+    const fn = ref[0];
     return scheduler().deleteScheduledJob(bot, fn)
       .then(function () {
         return sendMessage(bot, message, "Deleted scheduled job " + fn);
@@ -55,16 +55,16 @@ module.exports = function (bot) {
   });
 
   bot.respond(/schedule job (.+) [“”"'‘](.+)[“”"'’]$/i, function (message) {
-    var ref = message.match.slice(1);
-    var fn = ref[0];
-    var cronTime = ref[1];
+    const ref = message.match.slice(1);
+    const fn = ref[0];
+    const cronTime = ref[1];
     message.send("Scheduling Job");
     return scheduler().scheduleJob(bot, fn, cronTime)
       .then(function () {
         return scheduler().registerJob(fn, cronTime,
           {
-            send: function (msg, room = mainRoom) {
-              sendMessage(bot, message, msg, room);
+            send: function (msg, channel = room) {
+              sendMessage(bot, message, msg, channel);
             },
             bot
           }
@@ -76,8 +76,8 @@ module.exports = function (bot) {
   });
 
   bot.respond(/list scheduled jobs/i, function (message) {
-    var brainScheduledJobs = bot.brain.get(scheduler().JOBS);
-    var list = Object.keys(brainScheduledJobs || {}).reduce(function (o, d) {
+    const brainScheduledJobs = bot.brain.get(scheduler().JOBS);
+    const list = Object.keys(brainScheduledJobs || {}).reduce(function (o, d) {
       o += '[' + d + ']: ' + brainScheduledJobs[d][1] + '\n';
       return o;
     }, '');

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 var Scheduler = require('./lib/scheduler');
 
-module.exports = function(bot) {
+module.exports = function(bot){
   /*
   Description:
     Hubot job scheduler
@@ -20,21 +20,21 @@ module.exports = function(bot) {
 
   const room = process.env.HUBOT_JOB_CHANNEL;
 
-  function sendMessage(bot, message, msg, channel = room) {
+  function sendMessage(bot, message, msg, channel = room){
     bot.messageRoom(channel, msg);
-    if (message && message.envelope && message.envelope.room !== room) {
+    if (message && message.envelope && message.envelope.room !== room){
       message.send(msg);
     }
   }
 
   scheduler().initializeScheduledJobs(bot);
 
-  bot.respond(/run job (.+)$/i, function(message) {
+  bot.respond(/run job (.+)$/i, function(message){
     const ref = message.match.slice(1);
     const fn = ref[0];
     return scheduler().jobFunctions[fn](
       {
-        send: function(msg, channel = room) {
+        send: function(msg, channel = room){
           sendMessage(bot, message, msg, channel);
         },
         bot
@@ -42,42 +42,42 @@ module.exports = function(bot) {
     );
   });
 
-  bot.respond(/delete scheduled job (.+)$/i, function(message) {
+  bot.respond(/delete scheduled job (.+)$/i, function(message){
     const ref = message.match.slice(1);
     const fn = ref[0];
     return scheduler().deleteScheduledJob(bot, fn)
-      .then(function() {
+      .then(function(){
         return sendMessage(bot, message, "Deleted scheduled job " + fn);
       },
-        function(err) {
+        function(err){
           return sendMessage(bot, message, "Failed deletion of scheduled job " + fn);
         });
   });
 
-  bot.respond(/schedule job (.+) [“”"'‘](.+)[“”"'’]$/i, function(message) {
+  bot.respond(/schedule job (.+) [“”"'‘](.+)[“”"'’]$/i, function(message){
     const ref = message.match.slice(1);
     const fn = ref[0];
     const cronTime = ref[1];
     message.send("Scheduling Job");
     return scheduler().scheduleJob(bot, fn, cronTime)
-      .then(function() {
+      .then(function(){
         return scheduler().registerJob(fn, cronTime,
           {
-            send: function(msg, channel = room) {
+            send: function(msg, channel = room){
               sendMessage(bot, message, msg, channel);
             },
             bot
           }
         );
       })
-      .then(function() {
+      .then(function(){
         return sendMessage(bot, message, `Scheduled ${fn} '${cronTime}'`);
       });
   });
 
-  bot.respond(/list scheduled jobs/i, function(message) {
+  bot.respond(/list scheduled jobs/i, function(message){
     const brainScheduledJobs = bot.brain.get(scheduler().JOBS);
-    const list = Object.keys(brainScheduledJobs || {}).reduce(function(o, d) {
+    const list = Object.keys(brainScheduledJobs || {}).reduce(function(o, d){
       o += '[' + d + ']: ' + brainScheduledJobs[d][1] + '\n';
       return o;
     }, '');

--- a/index.js
+++ b/index.js
@@ -39,6 +39,9 @@ module.exports = function(bot){
       {
         send: function(msg){
           sendMessage(bot,message,msg);
+        },
+        messageRoom: function (msg, room) {
+          sendMessagetoRoom(bot, msg, room)
         }
       }
     );

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 var Scheduler = require('./lib/scheduler');
 
-module.exports = function (bot) {
+module.exports = function(bot) {
   /*
   Description:
     Hubot job scheduler
@@ -29,12 +29,12 @@ module.exports = function (bot) {
 
   scheduler().initializeScheduledJobs(bot);
 
-  bot.respond(/run job (.+)$/i, function (message) {
+  bot.respond(/run job (.+)$/i, function(message) {
     const ref = message.match.slice(1);
     const fn = ref[0];
     return scheduler().jobFunctions[fn](
       {
-        send: function (msg, channel = room) {
+        send: function(msg, channel = room) {
           sendMessage(bot, message, msg, channel);
         },
         bot
@@ -42,45 +42,45 @@ module.exports = function (bot) {
     );
   });
 
-  bot.respond(/delete scheduled job (.+)$/i, function (message) {
+  bot.respond(/delete scheduled job (.+)$/i, function(message) {
     const ref = message.match.slice(1);
     const fn = ref[0];
     return scheduler().deleteScheduledJob(bot, fn)
-      .then(function () {
+      .then(function() {
         return sendMessage(bot, message, "Deleted scheduled job " + fn);
       },
-        function (err) {
+        function(err) {
           return sendMessage(bot, message, "Failed deletion of scheduled job " + fn);
         });
   });
 
-  bot.respond(/schedule job (.+) [“”"'‘](.+)[“”"'’]$/i, function (message) {
+  bot.respond(/schedule job (.+) [“”"'‘](.+)[“”"'’]$/i, function(message) {
     const ref = message.match.slice(1);
     const fn = ref[0];
     const cronTime = ref[1];
     message.send("Scheduling Job");
     return scheduler().scheduleJob(bot, fn, cronTime)
-      .then(function () {
+      .then(function() {
         return scheduler().registerJob(fn, cronTime,
           {
-            send: function (msg, channel = room) {
+            send: function(msg, channel = room) {
               sendMessage(bot, message, msg, channel);
             },
             bot
           }
         );
       })
-      .then(function () {
+      .then(function() {
         return sendMessage(bot, message, `Scheduled ${fn} '${cronTime}'`);
       });
   });
 
-  bot.respond(/list scheduled jobs/i, function (message) {
+  bot.respond(/list scheduled jobs/i, function(message) {
     const brainScheduledJobs = bot.brain.get(scheduler().JOBS);
-    const list = Object.keys(brainScheduledJobs || {}).reduce(function (o, d) {
+    const list = Object.keys(brainScheduledJobs || {}).reduce(function(o, d) {
       o += '[' + d + ']: ' + brainScheduledJobs[d][1] + '\n';
       return o;
     }, '');
     sendMessage(bot, message, list.length && list || 'No scheduled jobs');
   });
-}
+};


### PR DESCRIPTION
exposing bot and message room to jobs so that they can send messages to other rooms and use other hubot functionalities

- [x] Semicolons - and other formatting
- [x] Test every function 
- [x] Const every variable that won’t change.
- [x] Abstract out code that is being used multiple times as a separate function
- [x] Don't use moment, request etc 
- [x] Don’t async functions that don’t need to be async
- [x] Add conditional chaining (?) when fields could not exist in objects
- [x] Maintain consistent casing for all variables, functions, files etc.
- [x] Remove extra spaces when they have been added
- [x] Always normalize casing for data when matching
- [x] If we can clues.reject use that instead of throw to prevent a large stack trace

